### PR TITLE
SafeParse in case we get values that are not parseable

### DIFF
--- a/hover-battery.js
+++ b/hover-battery.js
@@ -3,7 +3,9 @@
 const safeParse = (value) => {
   try {
     return JSON.parse(value)
-  } catch (error) { }
+  } catch (error) {
+    console.warn(`hover-battery could not parse ${value}`)
+  }
 }
 
 // helper function - builds a single init action group

--- a/hover-battery.js
+++ b/hover-battery.js
@@ -1,11 +1,21 @@
 
+// helper function - parses if we can, otherwise, return undefined
+const safeParse = (value) => {
+  try {
+    return JSON.parse(value)
+  } catch (error) { }
+}
+
 // helper function - builds a single init action group
-const buildInitAction = (storeName, initValue) => ({[storeName]: {init: () => initValue}})
+const buildInitAction = (storeName, initValue) => {
+  if (initValue) return {[storeName]: {init: () => initValue}}
+  return {}
+}
 
 // helper function - adds all the init actions for each store
 const addInitActions = (storage) => (memory, key) => {
   const value = (storage.getItem === undefined) ? storage[key] : storage.getItem(key)
-  return Object.assign({}, memory, buildInitAction(key, JSON.parse(value)))
+  return Object.assign({}, memory, buildInitAction(key, safeParse(value)))
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hover-battery",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hover-battery",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "LocalStorage / SessionStorage Memory for your Hover-Engine Store",
   "main": "hover-battery.js",
   "scripts": {

--- a/tests/specs/hover-battery-spec.js
+++ b/tests/specs/hover-battery-spec.js
@@ -17,6 +17,14 @@ describe('hover-battery', () => {
       expect(engine.store.todos).toEqual(['write tests'])
       expect(engine.store.timers).toEqual({email: true, work: false, break: true})
     })
+    it('should ignore default values that can\'t be parsed', () => {
+      objectStorage = {votes: 'INFO', todos: 'undefined', timers: '{"email": true, "work": false, "break": true}'}
+      engine.addActions(battery(objectStorage).actions)
+
+      expect(engine.store.votes).toEqual(0)
+      expect(engine.store.todos).toEqual([])
+      expect(engine.store.timers).toEqual({email: true, work: false, break: true})
+    })
     it('should write to the storage object', () => {
       engine.addListener(battery(objectStorage).listener)
       engine.actions.up()


### PR DESCRIPTION
## Summary

When using other libraries and projects with localStorage, sometimes we get unparsable values  (aka plain strings). This change allows hover-battery to ignore those values which we can't parse. 